### PR TITLE
Set user initiated to false.

### DIFF
--- a/service.py
+++ b/service.py
@@ -270,7 +270,7 @@ class AutoUpdater:
                 
         #run the clean operation
         utils.log("Cleaning Database")
-        xbmc.executebuiltin("CleanLibrary(" + media_type + ")")
+        xbmc.executebuiltin("CleanLibrary(" + media_type + “), false“)
 
         #write last run time, will trigger notifications
         self.writeLastRun()


### PR DESCRIPTION
Calling clean library with the user initiated flag set to false, it's true by default _AND_ it's not a documented feature of the built in function call.